### PR TITLE
Amount: Don't show minimum error if not set

### DIFF
--- a/includes/class-start.php
+++ b/includes/class-start.php
@@ -327,9 +327,7 @@ class Dmm_Start
 
                 if (empty($_POST['dmm_amount'])) {
                     $errors[] = __('Please choose an amount', 'doneren-met-mollie');
-                }
-
-                if ($_POST['dmm_amount'] < (float) get_option('dmm_minimum_amount', 1)) {
+                } elseif ($_POST['dmm_amount'] < (float) get_option('dmm_minimum_amount', 1)) {
                     $errors[] = __('The amount is too low, please choose a higher amount', 'doneren-met-mollie');
                 }
 


### PR DESCRIPTION
Currently, if the amount is not set, two errors will be printed - one that the amount is not set, and one that the amount is too low. This commit removes the second error if no amount has been entered.

In my opinion, it's a bit weird to show two errors for a single mistake: the user forgot to enter an amount. As such, I think it's better to only show the error that says no amount has been set.

Here's a screenshot of the current behaviour: if you don't enter an amount - two error items will show. This screenshot is from a website using the Dutch locale.

![image](https://github.com/user-attachments/assets/22051347-2224-45c7-84be-5933d57fed30)
